### PR TITLE
Fix casing for ENV prefix config

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The follow are sources in the form of `source-type://params`
 
 - `env-blob://ENV` - Represents an environment variable (the param) which contains a Base64 encoded JSON
 - `env-blob-gz://ENV` - Represent an environment variable (the param) which contains a Gzip'd Base64 encoded JSON
-- `env-prefix://PREFIX` - Fetches all environment variables that start with a prefix (the param). The prefix must be followed by two underscores. Any config key that has an underscore can be separated by double underscores. For example: "PREFIX__AUTH_CLIENT__SECRET=123" whould become "auth.client_secret=123".
+- `env-prefix://PREFIX` - Fetches all environment variables that start with a prefix (the param). The prefix must be followed by two underscores. Any config key that has an underscore can be separated by double underscores. For example: "PREFIX__auth_client__secret=123" whould become "auth.client_secret=123", while  "PREFIX__auth_clientSecret=123" whould become "auth.clientSecret=123". Any casing after the prefix is preserved.
 - `null://` - Represent a null source. No parameter. Used as fallback if the source is unparsable.
 
 ## Development

--- a/src/nativeMain/kotlin/com/zepben/zconf/sources/EnvPrefixSourceProcessor.kt
+++ b/src/nativeMain/kotlin/com/zepben/zconf/sources/EnvPrefixSourceProcessor.kt
@@ -26,7 +26,7 @@ class EnvPrefixSourceProcessor(
                     it[0] to it.subList(1, it.size).joinToString("=")
                 }
                 .filter { (k, _) ->
-                    k.startsWith(prefix)
+                    k.startsWith("${prefix}__")
                 }
         }
 
@@ -55,7 +55,6 @@ class EnvPrefixSourceProcessor(
                 .replace("__", "$") // escape double underscores
                 .replace("_", ".") // replace underscores for dots
                 .replace("$", "_") // put the escaped underscores back
-                .lowercase()
 
             config[resolvedKey] = value
         }

--- a/src/nativeTest/kotlin/com/zepben/zconf/sources/EnvPrefixSourceProcessorTest.kt
+++ b/src/nativeTest/kotlin/com/zepben/zconf/sources/EnvPrefixSourceProcessorTest.kt
@@ -17,11 +17,12 @@ class EnvPrefixSourceProcessorTest : FunSpec({
         val inputPrefix = "PREFIX"
         val fakeEnvFetcher = { input: String ->
             EnvPrefixSourceProcessor.getAllEnvsForPrefix(input, listOf(
-                "PREFIX__FOO_BAR=1",
-                "PREFIX__FOO_BAZ=2",
-                "PREFIX__THING_0=1",
-                "PREFIX__HAS__UNDERSCORE=10",
-                "OTHER__PREFIX_THING=1",
+                "PREFIX__foo_bar=1",
+                "PREFIX__foo_baz=2",
+                "PREFIX__thing_0=1",
+                "PREFIX__has__underscore=10",
+                "PREFIX__auth_camelCase=value",
+                "OTHER__prefix_thing=1",
                 "EXCLUDED=ENV"
             ))
         }
@@ -33,6 +34,7 @@ class EnvPrefixSourceProcessorTest : FunSpec({
             config["foo.baz"] shouldBe ConfigValue("2")
             config["thing.0"] shouldBe ConfigValue("1")
             config["has_underscore"] shouldBe ConfigValue("10")
+            config["auth.camelCase"] shouldBe ConfigValue("value")
 
 
             config["excluded"] shouldBe null
@@ -50,6 +52,7 @@ class EnvPrefixSourceProcessorTest : FunSpec({
             config["thing.0"] shouldBe null
             config["has_underscore"] shouldBe null
             config["excluded"] shouldBe null
+            config["auth.camelCase"] shouldBe null
         }
     }
 })


### PR DESCRIPTION
# Description

When I originally wrote the env prefix processor, I translated `PREFIX__FOO__BAR` into `foo_bar`, assuming that all our config keys were underscore based. However, `clientSecret` in the EAS config is camel case. In order to support camel case (and any other cases), This PR removes the `lowercase` transformation to that users of this application can just set the case they want for their config.

# Associated tasks

Jemena Deployment

# Test Steps

Green tests mean go

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [x] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Documentation
- [ ] ~I have updated the changelog.~
- [x] I have updated any documentation required for these changes.
