### PR TITLE
Updated zconf to support dots inside JSON object keys.

### DIFF
--- a/src/nativeTest/kotlin/com/zepben/zconf/sources/EnvBlobGzSourceProcessorTest.kt
+++ b/src/nativeTest/kotlin/com/zepben/zconf/sources/EnvBlobGzSourceProcessorTest.kt
@@ -37,18 +37,21 @@ class EnvBlobGzSourceProcessorTest : FunSpec({
     //                    "value": "Close",
     //                    "onclick": "CloseDoc()"
     //                }
-    //            ]
+    //            ],
+    //            "v1.kubernetes.zepben.com/node-class": "high-memory"
     //        }
     //    }
     //}
 
     test("parses a complex JSON var") {
-        val envVal = "H4sIAAAAAAAAA6tWyk3NK1WyUqjmUlBQykwBspTSMnNSlXRA/LLEnNJUkJAbXKggv6C0AKoeyAXpzixJzQWKRINFFBSqEdr8UsuVdBSU8vOSczKTs0EizkWpiSWpQHGX/GQNTaVaHUxN/gWpeWi6QEK4NTjn5BenotsDEoNqAeuIBZK1XLW1AKbny7HxAAAA"
+        val envVal =
+            "H4sIAAAAAAAAA5WOzQqCQBSF9z7FMKsCM9q2NVrWA0QLHU85OH+oY5T47s3gJBVItDv3O/d+3D4ihEooS7ekd9lNvHCZXrgAjUfSZcLCw/0bNNpYM10FC28hHTsFRqb203PALWhCoxUTnFW+S2tkLdzGTrPFkk5bQ/xDejRQs1Zf/itMhW4w/6dvv5UhnV9HtNsklc1RK7RokgdMDpUwLddKF1gxkTWNl5X8Wq4kpK7vo82bhmh4AmM9ctWfAQAA"
         val config = EnvBlobGzSourceProcessor("FAKE") { _ -> envVal }.properties as ConfigObject
 
         config["menu.id"] shouldBe ConfigValue("file")
         config["menu.value"] shouldBe ConfigValue("File")
         config["menu.popup.menuitem.0.value"] shouldBe ConfigValue("New")
+        config["menu.popup.v1__kubernetes__zepben__com/node-class"] shouldBe ConfigValue("high-memory")
     }
 
     test("safely fails for invalid gzip-ed data") {
@@ -56,8 +59,9 @@ class EnvBlobGzSourceProcessorTest : FunSpec({
         EnvBlobGzSourceProcessor("FAKE") { _ -> envVal }.properties
     }
 
-    test ("it works on something bigger than the intermediate buffer") {
-        val envVal = "H4sIAAAAAAAA/6yTz47kJhDG36WOkXEbg/9xi3aj3TkkWWnmFu0BQ9GN1g1eKE9rNOp3j/BMtyJNDjlEPlhAFUX9vq9eQW90AlX+1mMwCArEJLreCM2MdoLJ3sxslnxg0zj3UrbdIK2ACs5Ip2hBAQZK2luogNKWCe1DzhumDOovOBGtWR0OSzz6UJ+9STFHRzEsPmBt4vnAeS+k6GbWi9ExOcuBjdOEDI0ZBs7NOAh+eG7rBr5fK7Ca9Kwzlifb5J8xgYKYjvUaMx0T5p9L/fltv4JttZrw0ZzwrP8Mj6QTgaK04bUCvMxvbX9o33DHZWMdm4bWMKndxMYGOZNNN3Ixi9k0LVRgFo+BHux/B+Z3LKD+Vyj/osO1glPMVHYucx2QLjH9OEeLSx1iWFO07Hk1tb7k2geCCtZYwEgpKlhTpGjiAgq+Pj19e4QKEv7cMNPvtzJffnuCCp4xeffyCRN5542mQs7pJWMp78MRM8VUyKYtkD/vghGe12UPfQWdsz+Gb9u8ePOwgtpzC9XioPSHLhmAJrP397O9AVZkq8DEQNqHe9y9XgUZzZY8vXxJcVsf7G7CfGRNx6ceh9bOUzP1AxfwvYK8zQHpFrQvWCOmYRSis1r3vJOmh+p+1KEd3dS53lnnumn6x5HtzdS5buZtN8wD1+V60vnHZ3Q+ePIx/JoCKNApKH3JCk1WemU5bnRCnYm1auz40HZSTqPgquQye08+fKDAbj0rWQbvZX3nVfC/r+6U4HotYNI+La83czT1/t31H/pOVnDB+dPu7K9vUb/A9fo3AAAA//8BAAD//w/eRjwmBAAA"
+    test("it works on something bigger than the intermediate buffer") {
+        val envVal =
+            "H4sIAAAAAAAA/6yTz47kJhDG36WOkXEbg/9xi3aj3TkkWWnmFu0BQ9GN1g1eKE9rNOp3j/BMtyJNDjlEPlhAFUX9vq9eQW90AlX+1mMwCArEJLreCM2MdoLJ3sxslnxg0zj3UrbdIK2ACs5Ip2hBAQZK2luogNKWCe1DzhumDOovOBGtWR0OSzz6UJ+9STFHRzEsPmBt4vnAeS+k6GbWi9ExOcuBjdOEDI0ZBs7NOAh+eG7rBr5fK7Ca9Kwzlifb5J8xgYKYjvUaMx0T5p9L/fltv4JttZrw0ZzwrP8Mj6QTgaK04bUCvMxvbX9o33DHZWMdm4bWMKndxMYGOZNNN3Ixi9k0LVRgFo+BHux/B+Z3LKD+Vyj/osO1glPMVHYucx2QLjH9OEeLSx1iWFO07Hk1tb7k2geCCtZYwEgpKlhTpGjiAgq+Pj19e4QKEv7cMNPvtzJffnuCCp4xeffyCRN5542mQs7pJWMp78MRM8VUyKYtkD/vghGe12UPfQWdsz+Gb9u8ePOwgtpzC9XioPSHLhmAJrP397O9AVZkq8DEQNqHe9y9XgUZzZY8vXxJcVsf7G7CfGRNx6ceh9bOUzP1AxfwvYK8zQHpFrQvWCOmYRSis1r3vJOmh+p+1KEd3dS53lnnumn6x5HtzdS5buZtN8wD1+V60vnHZ3Q+ePIx/JoCKNApKH3JCk1WemU5bnRCnYm1auz40HZSTqPgquQye08+fKDAbj0rWQbvZX3nVfC/r+6U4HotYNI+La83czT1/t31H/pOVnDB+dPu7K9vUb/A9fo3AAAA//8BAAD//w/eRjwmBAAA"
         val config = EnvBlobGzSourceProcessor("FAKE") { _ -> envVal }.properties as ConfigObject
 
         config["server.host"] shouldBe ConfigValue("0.0.0.0")


### PR DESCRIPTION
# Description
Updated zconf to support dots inside JSON object keys. This functionality is needed for Kubernetes. We want to deploy pods to specific nodes and to do that we need to use labels that include dots in them.


# Associated tasks
NONE

# Test Steps
Try to use zconf to parse a config JSON object that contains keys with dots in them.

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [X] I have performed a self review of my own code (including checking issues raised when creating the PR).
- [X] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.
- [X] I have commented my code in any hard-to-understand or hacky areas.
- [X] I have handled all new warnings generated by the compiler or IDE.
- [X]I have rebased onto the target branch (usually main).

### Documentation
~- [ ] I have updated the changelog.~
~- [ ] I have updated any documentation required for these changes.~

# Breaking Changes
- [X] I have considered if this is a breaking change and will communicate it with other team members if so.

It is indeed a breaking change because it modifies the parsing behaviour. Previously it would create nested JSON objects if dots where found in keys but that behaviour is not desired and no one should be relying on it.