### PR TITLE
[Chore] Bump dependencies

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,6 @@ kotlinxSerializationJson = { module = "org.jetbrains.kotlinx:kotlinx-serializati
 kotlinxIoCore = { module = "org.jetbrains.kotlinx:kotlinx-io-core", version.ref = "kotlinxIo" }
 clikt = { module = "com.github.ajalt.clikt:clikt", version.ref = "clikt" }
 koTestFramework = { module = "io.kotest:kotest-framework-engine", version.ref = "koTest" }
-koTestAssertion = { module = "io.kotest:kotest-assertions-core", version.ref = "koTest" }
 kotlinLogger = { module = "io.github.oshai:kotlin-logging", version.ref = "kotlinLogger" }
 
 [plugins]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-kotlin = "2.0.20"
+kotlin = "2.1.10"
 kotlinxSerialization = "1.7.2"
 kotlinxIo = "0.5.3"
 clikt = "4.2.2"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,7 +3,7 @@ kotlin = "2.0.20"
 kotlinxSerialization = "1.7.2"
 kotlinxIo = "0.5.3"
 clikt = "4.2.2"
-koTest = "6.0.0-SNAPSHOT"
+koTest = "6.0.0.M1"
 kotlinLogger = "5.1.4"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 kotlin = "2.1.10"
 kotlinxSerialization = "1.8.0"
 kotlinxIo = "0.7.0"
-clikt = "4.2.2"
+clikt = "4.4.0"
 koTest = "6.0.0.M2"
 kotlinLogger = "5.1.4"
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@ kotlinxSerialization = "1.8.0"
 kotlinxIo = "0.7.0"
 clikt = "4.4.0"
 koTest = "6.0.0.M2"
-kotlinLogger = "5.1.4"
+kotlinLogger = "7.0.5"
 
 [libraries]
 kotlinxSerializationJson = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerialization" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,9 +1,9 @@
 [versions]
 kotlin = "2.1.10"
-kotlinxSerialization = "1.7.2"
+kotlinxSerialization = "1.8.0"
 kotlinxIo = "0.5.3"
 clikt = "4.2.2"
-koTest = "6.0.0.M1"
+koTest = "6.0.0.M2"
 kotlinLogger = "5.1.4"
 
 [libraries]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 kotlin = "2.1.10"
 kotlinxSerialization = "1.8.0"
-kotlinxIo = "0.5.3"
+kotlinxIo = "0.7.0"
 clikt = "4.2.2"
 koTest = "6.0.0.M2"
 kotlinLogger = "5.1.4"

--- a/src/nativeMain/kotlin/com/zepben/zconf/Main.kt
+++ b/src/nativeMain/kotlin/com/zepben/zconf/Main.kt
@@ -7,13 +7,6 @@ package com.zepben.zconf
 
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.subcommands
-import com.zepben.zconf.sources.EnvBlobSourceProcessor
-import com.zepben.zconf.util.Gzip
-import kotlinx.cinterop.ExperimentalForeignApi
-import kotlinx.cinterop.toKString
-import platform.posix.getenv
-import kotlin.io.encoding.Base64
-import kotlin.io.encoding.ExperimentalEncodingApi
 
 class Main: CliktCommand(name = "zconf") {
     override fun run() {

--- a/src/nativeMain/kotlin/com/zepben/zconf/sources/EnvBlobGzSourceProcessor.kt
+++ b/src/nativeMain/kotlin/com/zepben/zconf/sources/EnvBlobGzSourceProcessor.kt
@@ -8,10 +8,7 @@ package com.zepben.zconf.sources
 import com.zepben.zconf.util.Gzip
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.toKString
-import kotlinx.serialization.json.*
 import platform.posix.getenv
-import kotlin.io.encoding.Base64
-import kotlin.io.encoding.ExperimentalEncodingApi
 
 open class EnvBlobGzSourceProcessor @OptIn(ExperimentalForeignApi::class) constructor(
     input: String,

--- a/src/nativeMain/kotlin/com/zepben/zconf/util/Gzip.kt
+++ b/src/nativeMain/kotlin/com/zepben/zconf/util/Gzip.kt
@@ -49,7 +49,7 @@ class Gzip {
 
                 inflateEnd(stream.ptr)
 
-                return output.readByteArray()
+                return output.readByteArray(stream.total_out.toInt())
             }
         }
     }

--- a/src/nativeMain/kotlin/com/zepben/zconf/util/Gzip.kt
+++ b/src/nativeMain/kotlin/com/zepben/zconf/util/Gzip.kt
@@ -6,7 +6,6 @@
 package com.zepben.zconf.util
 
 import io.github.oshai.kotlinlogging.KotlinLogging
-import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.*
 import kotlinx.io.Buffer
 import kotlinx.io.readByteArray

--- a/src/nativeMain/kotlin/com/zepben/zconf/util/Output.kt
+++ b/src/nativeMain/kotlin/com/zepben/zconf/util/Output.kt
@@ -9,7 +9,6 @@ import kotlinx.io.Buffer
 import kotlinx.io.IOException
 import kotlinx.io.files.Path
 import kotlinx.io.files.SystemFileSystem
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 

--- a/src/nativeTest/kotlin/com/zepben/zconf/model/ConfigElementTest.kt
+++ b/src/nativeTest/kotlin/com/zepben/zconf/model/ConfigElementTest.kt
@@ -9,7 +9,6 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 
 class ConfigModelTest : FunSpec({

--- a/src/nativeTest/kotlin/com/zepben/zconf/sources/EnvBlobGzSourceProcessorTest.kt
+++ b/src/nativeTest/kotlin/com/zepben/zconf/sources/EnvBlobGzSourceProcessorTest.kt
@@ -45,7 +45,7 @@ class EnvBlobGzSourceProcessorTest : FunSpec({
 
     test("parses a complex JSON var") {
         val envVal =
-            "H4sIAAAAAAAAA5WOzQqCQBSF9z7FMKsCM9q2NVrWA0QLHU85OH+oY5T47s3gJBVItDv3O/d+3D4ihEooS7ekd9lNvHCZXrgAjUfSZcLCw/0bNNpYM10FC28hHTsFRqb203PALWhCoxUTnFW+S2tkLdzGTrPFkk5bQ/xDejRQs1Zf/itMhW4w/6dvv5UhnV9HtNsklc1RK7RokgdMDpUwLddKF1gxkTWNl5X8Wq4kpK7vo82bhmh4AmM9ctWfAQAA"
+            "H4sIAAAAAAAAA5WOzQqCQBSF9z6FzKrAjLZtjZb1ANFCx1MOzh+OY5T47s3gJBVItDv3O/d+3D6KYyIgLdnGvctuYqXL5MI4SDKSLucWHu7foFba6ukqWFgL4dgpsHhqPz0H3IImNEpSzmjtu6xB3sJt7BRdLMm0NSQ/pEcNOWv15b/CjCuD+T99+60M6fw6It0mrW2BRqKFSR/QBWRKlVhLVWJFeW6Ml1XsWq0EhGruo82bhmiInkxEueagAQAA"
         val config = EnvBlobGzSourceProcessor("FAKE") { _ -> envVal }.properties as ConfigObject
 
         config["menu.id"] shouldBe ConfigValue("file")


### PR DESCRIPTION
# Description

Just doing a bump on dependencies. Things of note are:

- There is warning in Kotest that is emitted re: some IR generation. This will probably be fixed in the future version
- We cannot upgrade to the latest version of Click: 5.0.3 due to a kotlin native build cache issue
- The change is `Gzip.kt` was due to a buffer overrun when reading the final output buffer. Why its happening now is unknown, but bounding the number of bytes returned to the bytes processed by Zlib seems to fix the issue.