### PR TITLE
[DEV-9268] Make this thing work on Windows

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN ./gradlew linkReleaseExecutableNative
 
 FROM scratch
 
-COPY --from=build /app/build/bin/native/releaseExecutable/zconf.kexe /zconf
+COPY --from=build /app/build/bin/linuxX64/releaseExecutable/zconf.kexe /zconf
 
 # Hack: Unfortunately Kotlin Native doesn't easily support static linking of the executable just yet. Until we do
 # we need to copy any dynamic libraries. Thankfully, what we need seems to be present in our runtime images

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,7 +1,9 @@
 /*
- * Copyright (c) Zeppelin Bend Pty Ltd (Zepben) 2024 - All Rights Reserved.
+ * Copyright (c) Zeppelin Bend Pty Ltd (Zepben) 2026 - All Rights Reserved.
  * Unauthorized use, copy, or distribution of this file or its contents, via any medium is strictly prohibited.
  */
+
+import org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTarget
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -23,37 +25,67 @@ repositories {
 }
 
 kotlin {
-    val hostOs = System.getProperty("os.name")
-    val isArm64 = System.getProperty("os.arch") == "aarch64"
-    val isMingwX64 = hostOs.startsWith("Windows")
-    val nativeTarget = when {
-        hostOs == "Mac OS X" && isArm64 -> macosArm64("native")
-        hostOs == "Mac OS X" && !isArm64 -> macosX64("native")
-        hostOs == "Linux" && isArm64 -> linuxArm64("native")
-        hostOs == "Linux" && !isArm64 -> linuxX64("native")
-        isMingwX64 -> mingwX64("native")
-        else -> throw GradleException("Host OS is not supported in Kotlin/Native.")
-    }
+    val linuxTargets = listOf(linuxX64(), linuxArm64())
+    val macosTargets = listOf(macosX64(), macosArm64())
+    val windowsTargets = listOf(mingwX64())
+    val allTargets = linuxTargets + macosTargets + windowsTargets
 
-    nativeTarget.apply {
-        binaries {
-            executable {
-                entryPoint = "$group.main"
-            }
+    allTargets.forEach { target ->
+        target.binaries {
+            executable { entryPoint = "$group.main" }
         }
     }
 
     sourceSets {
-        nativeMain.dependencies {
-            implementation(libs.kotlinxSerializationJson)
-            implementation(libs.kotlinxIoCore)
-            implementation(libs.clikt)
-            implementation(libs.kotlinLogger)
+        val nativeMain by creating {
+            dependencies {
+                implementation(libs.kotlinxSerializationJson)
+                implementation(libs.kotlinxIoCore)
+                implementation(libs.clikt)
+                implementation(libs.kotlinLogger)
+            }
+        }
+        val linuxMain by creating { dependsOn(nativeMain) }
+        val macosMain by creating { dependsOn(nativeMain) }
+        val windowsMain by creating { dependsOn(nativeMain) }
+
+        val nativeTest by creating {
+            dependencies {
+                implementation(libs.koTestFramework)
+                implementation(libs.koTestAssertions)
+            }
         }
 
-        nativeTest.dependencies {
-            implementation(libs.koTestFramework)
-            implementation(libs.koTestAssertions)
+        linuxTargets.forEach { it.compilations["main"].defaultSourceSet.dependsOn(linuxMain) }
+        macosTargets.forEach { it.compilations["main"].defaultSourceSet.dependsOn(macosMain) }
+        windowsTargets.forEach { it.compilations["main"].defaultSourceSet.dependsOn(windowsMain) }
+        allTargets.forEach { it.compilations["test"].defaultSourceSet.dependsOn(nativeTest) }
+    }
+}
+
+val hostOs: String = System.getProperty("os.name")
+val isArm64: Boolean = System.getProperty("os.arch") == "aarch64"
+val hostTargetName: String = when {
+    hostOs.startsWith("Windows") -> "mingwX64"
+    hostOs == "Mac OS X" && isArm64 -> "macosArm64"
+    hostOs == "Mac OS X" -> "macosX64"
+    isArm64 -> "linuxArm64"
+    else -> "linuxX64"
+}
+
+// Only compile for the host platform
+afterEvaluate {
+    kotlin.targets.withType<KotlinNativeTarget>().configureEach {
+        if (name != hostTargetName) {
+            val suffix = name.replaceFirstChar { it.uppercase() }
+            tasks.matching { it.name.endsWith(suffix) }.configureEach { enabled = false }
         }
     }
+}
+
+// The linkReleaseExecutableNative task should just compile for the host platform
+tasks.register("linkReleaseExecutableNative") {
+    group = "build"
+    description = "Alias for the host-platform release link task (for CI compatibility)."
+    dependsOn("linkReleaseExecutable${hostTargetName.replaceFirstChar { it.uppercase() }}")
 }

--- a/src/linuxMain/kotlin/com/zepben/zconf/sources/PlatformUtils.kt
+++ b/src/linuxMain/kotlin/com/zepben/zconf/sources/PlatformUtils.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.zconf.sources
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.get
+import kotlinx.cinterop.toKString
+import platform.posix.NULL
+import platform.posix.__environ
+
+internal actual object PlatformUtils {
+    @OptIn(ExperimentalForeignApi::class)
+    actual fun getAllEnvs(): List<String> {
+        var index = 0
+        val envs = mutableListOf<String>()
+        while (__environ?.get(index) != NULL) {
+            val env = __environ?.get(index)?.toKString() ?: throw IllegalStateException("Should never be null")
+            envs.add(env)
+            index += 1
+        }
+        return envs
+    }
+}

--- a/src/macosMain/kotlin/com/zepben/zconf/sources/PlatformUtils.kt
+++ b/src/macosMain/kotlin/com/zepben/zconf/sources/PlatformUtils.kt
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2026 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.zconf.sources
+
+import platform.Foundation.NSProcessInfo
+
+internal actual object PlatformUtils {
+    actual fun getAllEnvs(): List<String> {
+        return NSProcessInfo.processInfo.environment.map { (key, value) -> "$key=$value" }
+    }
+}

--- a/src/nativeMain/kotlin/com/zepben/zconf/sources/EnvPrefixSourceProcessor.kt
+++ b/src/nativeMain/kotlin/com/zepben/zconf/sources/EnvPrefixSourceProcessor.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Zeppelin Bend Pty Ltd
+ * Copyright 2026 Zeppelin Bend Pty Ltd
  *
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -10,11 +10,6 @@ package com.zepben.zconf.sources
 
 import com.zepben.zconf.model.ConfigElement
 import com.zepben.zconf.model.ConfigObject
-import kotlinx.cinterop.ExperimentalForeignApi
-import kotlinx.cinterop.get
-import kotlinx.cinterop.toKString
-import platform.posix.NULL
-import platform.posix.__environ
 
 class EnvPrefixSourceProcessor(
     input: String,
@@ -22,7 +17,7 @@ class EnvPrefixSourceProcessor(
 ) : SourceProcessor(input) {
 
     companion object {
-        fun getAllEnvsForPrefix(prefix: String, envs: List<String> = getAllEnvs()): Map<String, String> {
+        fun getAllEnvsForPrefix(prefix: String, envs: List<String> = PlatformUtils.getAllEnvs()): Map<String, String> {
             return envs.map { it.split("=") }
                 .associate {
                     // preserve any envs with an equal sign in it
@@ -31,21 +26,6 @@ class EnvPrefixSourceProcessor(
                 .filter { (k, _) ->
                     k.startsWith("${prefix}__")
                 }
-        }
-
-        @OptIn(ExperimentalForeignApi::class)
-        private fun getAllEnvs(
-        ): MutableList<String> {
-            var index = 0
-            val envs = mutableListOf<String>()
-
-            while (__environ?.get(index) != NULL) {
-                val env = __environ?.get(index)?.toKString() ?: throw IllegalStateException("Should never be null")
-                envs.add(env)
-                index += 1
-            }
-
-            return envs
         }
     }
 

--- a/src/nativeMain/kotlin/com/zepben/zconf/sources/PlatformUtils.kt
+++ b/src/nativeMain/kotlin/com/zepben/zconf/sources/PlatformUtils.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright 2026 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.zconf.sources
+
+internal expect object PlatformUtils {
+    fun getAllEnvs(): List<String>
+}

--- a/src/windowsMain/kotlin/com/zepben/zconf/sources/PlatformUtils.kt
+++ b/src/windowsMain/kotlin/com/zepben/zconf/sources/PlatformUtils.kt
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 Zeppelin Bend Pty Ltd
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+package com.zepben.zconf.sources
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.get
+import kotlinx.cinterop.toKString
+import platform.posix.NULL
+import platform.posix._environ
+
+internal actual object PlatformUtils {
+    @OptIn(ExperimentalForeignApi::class)
+    actual fun getAllEnvs(): List<String> {
+        var index = 0
+        val envs = mutableListOf<String>()
+        while (_environ?.get(index) != NULL) {
+            val env = _environ?.get(index)?.toKString() ?: throw IllegalStateException("Should never be null")
+            envs.add(env)
+            index += 1
+        }
+        return envs
+    }
+}


### PR DESCRIPTION
# Description

I have a Windows dev environment, and I am unable to build zconf locally without changing the code to accommodate the mingw64 kotlin native bindings.

To future-proof development of zconf, we should allow devs to build this application on any platform - even if we know in production it'll only get run on Linux.

This PR creates platform-specific implementations of the function that fetches Environment Variables.

I have also modified build.gradle.kts such that:
- The IDE recognises the individual platform-specific modules properly
- The build still only builds for the host platform

# Test Steps

Ensure this builds locally for development on both Windows, Linux and Mac (if we can find a Mac).

# Checklist

If any of these are not applicable, strikethrough the line `~like this~`. **Do not delete it!**. Let the reviewer decide if you should have done it.

### Code
- [x] I have performed a self review of my own code (including checking issues raised when creating the PR).
- ~[ ] I have added/updated unit tests for these changes, and if not I have explained why they are not necessary.~ Existing unit tests should protect us against unintentional changes as a result of this.
- [x] I have commented my code in any hard-to-understand or hacky areas.
- [x] I have handled all new warnings generated by the compiler or IDE.
- [x] I have rebased onto the target branch (usually main).

### Security
When developing applications, use following guidelines for information security considerations:
* Access to applications should be protected with security keys/tokens or usernames and passwords;
* All sessions are encrypted if possible;
* All application input is sanitised before being acted on (ie SQL statements, etc);
* Log messages, and especially client-facing ones, must be handled securely and must not leak credentials information (internal URLs, passwords, tokens).

- [x] I have considered if this change impacts information security and made sure those impacts are handled.

No security impact.

### Documentation
- ~[ ] I have updated the changelog.~ No changelog in this repo. Should I add one?
- ~[ ] I have updated any documentation required for these changes.~ Not necessary.

# Breaking Changes
- [x] I have considered if this is a breaking change and will communicate it with other team members by posting it on the Slack **breaking-changes** channel.

No breaking changes.