### PR TITLE
Run tests on PR and fix bug

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -5,7 +5,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    container: zepben/pipeline-basic
+    container: zepben/pipeline-java
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -21,3 +21,6 @@ jobs:
         with:
           LC_URL: ${{ secrets.LC_URL }}
           PATH: "src"
+
+      - name: Build
+        run: ./gradlew build

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -8,7 +8,7 @@ jobs:
     container: zepben/pipeline-java
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Cache licence-check
         uses: actions/cache@v3

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ build/
 !**/src/test/**/build/
 
 ### IntelliJ IDEA ###
+.idea
 .idea/modules.xml
 .idea/jarRepositories.xml
 .idea/compiler.xml
@@ -40,3 +41,6 @@ bin/
 
 ### Mac OS ###
 .DS_Store
+
+# Kotlin
+.kotlin

--- a/src/nativeMain/kotlin/com/zepben/zconf/util/Gzip.kt
+++ b/src/nativeMain/kotlin/com/zepben/zconf/util/Gzip.kt
@@ -5,10 +5,10 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
-
 package com.zepben.zconf.util
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.cinterop.UnsafeNumber
 import kotlinx.cinterop.*
 import kotlinx.io.Buffer
 import kotlinx.io.readByteArray
@@ -19,7 +19,7 @@ class Gzip {
         private val logger = KotlinLogging.logger {}
 
         private const val BUFFER_MAX = 1024
-        @OptIn(ExperimentalForeignApi::class)
+        @OptIn(ExperimentalForeignApi::class, UnsafeNumber::class)
         fun decode(compressed: ByteArray): ByteArray {
             memScoped {
                 val stream = alloc<z_stream>()


### PR DESCRIPTION
I think that PRs did not trigger test runs, and this made it possible for regressions to sneak in. Add that support now to prevent this issue in the future.

Also fix error that prevented compilation on Linux

My understanding of this bug, and I am a Kotlin novice, is that now we
have other OS targets, Kotlin automatically annotates certain fields
with UnsafeNumber if they are not the same size on all Operating
systems. `zstream.total_out` is one of these, so Kotlin rejects it. We add
this annotation to say it is OK, allowing compilation to proceed.
Runtime behaviour is as it was before.
